### PR TITLE
YIEL-3453: Handle lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ return (
 | `optDiv` | string | true | name of DIV ID of given adUnit |
 | `targeting` | object | false | extra targeting object which can be used to pass aditional key-values pairs to GAM |
 | `sizeMapping` | array | false | array representation of size mapping GPT command calls. Each array element consists of two more arrays, representing viewport size and mapping which correspnds to [GPT setup](https://developers.google.com/publisher-tag/reference#googletag.sizemappingbuilder). |
+| `lazyLoad` | boolean | false | whether given adUnit should be lazy loaded |
 
 ### Additional targeting example
 ```tsx

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -27,10 +27,21 @@ const App = () => {
               test: 'ao',
               foo: 'bar'
             }}
+            lazyLoad={true}
           /> }
         </div>
         <button onClick={buttonHandler}>Toggle {toggle ? 'OFF' : 'ON'} ads</button>
+        <div>
+          AD 2
+        </div>
       </div>
+      <AdManagerSlot
+        adUnitPath={config.unitPath2}
+        className='test2'
+        size={[[336, 280]]}
+        optDiv={config.optDiv2}
+        lazyLoad={true}
+      />
     </AdManagerProvider>
   )
 }

--- a/example/src/index.css
+++ b/example/src/index.css
@@ -12,3 +12,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.test2 {
+  margin-top: 1200px;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yieldbird_gpt_components",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Made with create-react-library",
   "author": "YieldbirdDev",
   "license": "MIT",
@@ -67,5 +67,8 @@
   ],
   "dependencies": {
     "improved-yarn-audit": "^2.3.2"
+  },
+  "resolutions": {
+    "**/immer": "^8.0.1"
   }
 }

--- a/src/Components/AdManagerSlot.test.tsx
+++ b/src/Components/AdManagerSlot.test.tsx
@@ -12,38 +12,11 @@ const mockScripts = () => {
   window.Yieldbird = {
     cmd: [],
     setGPTTargeting: () => {},
-    refresh: (_slots) => {}
+    refresh: (_slots) => {},
+    retarget: (_slots) => {}
   }
 
   window.googletag = new GPT()
-}
-
-const TestComponent = () => {
-  const [toggle, setToggle] = useState<boolean>(true)
-  const buttonHandler = useCallback(() => {
-    setToggle(!toggle)
-  }, [toggle, setToggle])
-
-  return (
-    <AdManagerProvider uuid='a81dc6d2-be53-4481-9012-812bbbec9109'>
-      <div>
-        <div>
-          AD 1
-          {toggle && (
-            <AdManagerSlot
-              adUnitPath='52555387/dazzling.news_160x600'
-              size={[
-                [120, 600],
-                [160, 600]
-              ]}
-              optDiv='paralos-300x250_mobile'
-            />
-          )}
-        </div>
-        <button onClick={buttonHandler}>Toggle ads</button>
-      </div>
-    </AdManagerProvider>
-  )
 }
 
 describe('AdManagerSlot', () => {
@@ -63,67 +36,190 @@ describe('AdManagerSlot', () => {
     jest.clearAllTimers()
   })
 
-  it('renders slot properly', async () => {
-    const wrapper = mount(
-      <AdManagerProvider uuid='bar'>
-        <AdManagerSlot adUnitPath='/foo' size={[200, 300]} optDiv='foo' />
-      </AdManagerProvider>
-    )
+  describe('for regular adUnits', () => {
+    const TestComponent = () => {
+      const [toggle, setToggle] = useState<boolean>(true)
+      const buttonHandler = useCallback(() => {
+        setToggle(!toggle)
+      }, [toggle, setToggle])
 
-    await act(async () => {
-      wrapper.update()
+      return (
+        <AdManagerProvider uuid='a81dc6d2-be53-4481-9012-812bbbec9109'>
+          <div>
+            <div>
+              AD 1
+              {toggle && (
+                <AdManagerSlot
+                  adUnitPath='52555387/dazzling.news_160x600'
+                  size={[
+                    [120, 600],
+                    [160, 600]
+                  ]}
+                  optDiv='paralos-300x250_mobile'
+                />
+              )}
+            </div>
+            <button onClick={buttonHandler}>Toggle ads</button>
+          </div>
+        </AdManagerProvider>
+      )
+    }
+
+    it('renders slot properly', async () => {
+      const wrapper = mount(
+        <AdManagerProvider uuid='bar'>
+          <AdManagerSlot adUnitPath='/foo' size={[200, 300]} optDiv='foo' />
+        </AdManagerProvider>
+      )
+
+      await act(async () => {
+        wrapper.update()
+      })
+
+      expect(wrapper.find('#foo')).toBeTruthy()
+      expect(window.googletag.cmd).toHaveLength(1)
+      expect(window.Yieldbird.cmd).toHaveLength(1)
     })
 
-    expect(wrapper.find('#foo')).toBeTruthy()
-    expect(window.googletag.cmd).toHaveLength(1)
-    expect(window.Yieldbird.cmd).toHaveLength(1)
+    it('runs proper GPT & Yieldbird commands', async () => {
+      const wrapper = mount(<TestComponent />)
+
+      await act(async () => {
+        wrapper.update()
+      })
+
+      // disable initial load command
+      window.googletag.cmd[0]()
+
+      // create slot commands
+      window.Yieldbird.cmd[0]()
+      window.googletag.cmd[1]()
+
+      expect(window.googletag.enableServices).toHaveBeenCalledTimes(1)
+      expect(window.googletag.defineSlot).toHaveBeenCalledTimes(1)
+      expect(window.googletag.display).toHaveBeenCalledTimes(1)
+      expect(window.Yieldbird.setGPTTargeting).toHaveBeenCalledTimes(1)
+
+      expect(window.Yieldbird.cmd).toHaveLength(1)
+      expect(window.googletag.cmd).toHaveLength(2)
+      await wrapper.find('button').simulate('click')
+
+      expect(window.googletag.cmd).toHaveLength(3)
+      // destroy slot command
+      window.googletag.cmd[2]()
+
+      expect(window.googletag.destroySlots).toHaveBeenCalledTimes(1)
+      await wrapper.find('button').simulate('click')
+
+      // create slot command again
+      expect(window.Yieldbird.cmd).toHaveLength(2)
+      window.Yieldbird.cmd[1]()
+      window.googletag.cmd[3]()
+
+      expect(window.googletag.enableServices).toHaveBeenCalledTimes(2)
+      expect(window.googletag.defineSlot).toHaveBeenCalledTimes(2)
+      expect(window.googletag.display).toHaveBeenCalledTimes(2)
+      expect(window.Yieldbird.setGPTTargeting).toHaveBeenCalledTimes(1)
+
+      await jest.advanceTimersByTime(5000)
+      jest.runAllTimers()
+
+      expect(window.Yieldbird.cmd).toHaveLength(3)
+      window.Yieldbird.cmd[2]()
+      expect(window.Yieldbird.refresh).toHaveBeenCalledTimes(1)
+    })
   })
 
-  it('runs proper GPT & Yieldbird commands', async () => {
-    const wrapper = mount(<TestComponent />)
+  describe('for lazy ad units', () => {
+    const TestLazyComponent = () => {
+      return (
+        <AdManagerProvider uuid='a81dc6d2-be53-4481-9012-812bbbec9109'>
+          <div>
+            <div>
+              AD 1
+              <AdManagerSlot
+                adUnitPath='52555387/dazzling.news_160x600'
+                size={[
+                  [120, 600],
+                  [160, 600]
+                ]}
+                optDiv='paralos-300x250_mobile'
+                lazyLoad
+              />
+            </div>
+          </div>
+        </AdManagerProvider>
+      )
+    }
 
-    await act(async () => {
-      wrapper.update()
+    class IntersectionObserver {
+      readonly root: Element | null
+
+      readonly rootMargin: string
+
+      readonly thresholds: ReadonlyArray<number>
+      constructor(private func: Function) {
+        this.func = func
+        this.root = null
+        this.rootMargin = ''
+        this.thresholds = []
+      }
+
+      observe(element: HTMLElement) {
+        this.func([{ isIntersecting: true, target: element }], this)
+      }
+
+      disconnect() {
+        return null
+      }
+
+      takeRecords(): IntersectionObserverEntry[] {
+        return []
+      }
+
+      unobserve() {
+        return null
+      }
+    }
+
+    beforeEach(() => {
+      const div = document.createElement('div')
+
+      div.setAttribute('id', 'container')
+      document.body.appendChild(div)
+      global.IntersectionObserver = IntersectionObserver
+      spyOn(
+        global.IntersectionObserver.prototype,
+        'unobserve'
+      ).and.callThrough()
     })
 
-    // disable initial load command
-    window.googletag.cmd[0]()
+    it('runs proper GPT & Yieldbird commands', async () => {
+      const wrapper = mount(<TestLazyComponent />, {
+        attachTo: document.getElementById('container')
+      })
 
-    // create slot commands
-    window.Yieldbird.cmd[0]()
-    window.googletag.cmd[1]()
+      await act(async () => {
+        wrapper.update()
+      })
 
-    expect(window.googletag.enableServices).toHaveBeenCalledTimes(1)
-    expect(window.googletag.defineSlot).toHaveBeenCalledTimes(1)
-    expect(window.googletag.display).toHaveBeenCalledTimes(1)
-    expect(window.Yieldbird.setGPTTargeting).toHaveBeenCalledTimes(1)
+      // disable initial load command
+      window.googletag.cmd[0]()
 
-    expect(window.Yieldbird.cmd).toHaveLength(1)
-    expect(window.googletag.cmd).toHaveLength(2)
-    await wrapper.find('button').simulate('click')
+      // create slot commands
+      window.Yieldbird.cmd[0]()
+      window.googletag.cmd[1]()
 
-    expect(window.googletag.cmd).toHaveLength(3)
-    // destroy slot command
-    window.googletag.cmd[2]()
+      expect(window.googletag.enableServices).toHaveBeenCalledTimes(1)
+      expect(window.googletag.defineSlot).toHaveBeenCalledTimes(1)
+      expect(window && 'IntersectionObserver' in window).toEqual(true)
 
-    expect(window.googletag.destroySlots).toHaveBeenCalledTimes(1)
-    await wrapper.find('button').simulate('click')
+      await jest.advanceTimersByTime(5000)
+      jest.runAllTimers()
 
-    // create slot command again
-    expect(window.Yieldbird.cmd).toHaveLength(2)
-    window.Yieldbird.cmd[1]()
-    window.googletag.cmd[3]()
-
-    expect(window.googletag.enableServices).toHaveBeenCalledTimes(2)
-    expect(window.googletag.defineSlot).toHaveBeenCalledTimes(2)
-    expect(window.googletag.display).toHaveBeenCalledTimes(2)
-    expect(window.Yieldbird.setGPTTargeting).toHaveBeenCalledTimes(1)
-
-    await jest.advanceTimersByTime(5000)
-    jest.runAllTimers()
-
-    expect(window.Yieldbird.cmd).toHaveLength(3)
-    window.Yieldbird.cmd[2]()
-    expect(window.Yieldbird.refresh).toHaveBeenCalledTimes(1)
+      window.googletag.cmd[2]()
+      expect(window.googletag.display).toHaveBeenCalledTimes(1)
+      expect(global.IntersectionObserver.prototype.unobserve).toHaveBeenCalled()
+    })
   })
 })

--- a/src/Context/AdManagerProvider.tsx
+++ b/src/Context/AdManagerProvider.tsx
@@ -3,15 +3,20 @@ import React, { useCallback, useEffect, useState } from 'react'
 import { AdManager } from '../Utils/AdManager'
 import { initializeAdStack } from '../Utils/headerScripts'
 
+import { isIntersectionObserverAvailable } from '../Utils/intersectionObserver'
+
 interface Props {
   uuid: string
   refreshDelay?: number
 }
 
 export const AdManagerContext = React.createContext({
+  addToLazyLoad: (_optDiv: string): void => {},
+  addToLazyWithRetarget: (_slot: googletag.Slot, _optDiv: string): void => {},
   shouldRefresh: (_optDiv: string) => false as boolean,
   refreshAd: (_slot: googletag.Slot, _optDiv: string): void => {},
-  registerSlot: (_slot: googletag.Slot): void => {}
+  registerSlot: (_slot: googletag.Slot): void => {},
+  removeFromLazyLoad: (_optDiv: string): void => {}
 })
 
 export const AdManagerProvider: React.FC<Props> = ({
@@ -19,8 +24,47 @@ export const AdManagerProvider: React.FC<Props> = ({
   uuid,
   refreshDelay
 }) => {
-  const adManager = new AdManager(refreshDelay)
   const [adsMap, setAdsMap] = useState<string[]>([])
+
+  const adManager = new AdManager(refreshDelay)
+  const intersectionObserver =
+    isIntersectionObserverAvailable() &&
+    new IntersectionObserver((entries, observer) => {
+      const actionEntries = entries.filter((entry) => entry.isIntersecting)
+
+      if (actionEntries.length > 0) {
+        window &&
+          window.googletag.cmd.push(() => {
+            const displayEntries = actionEntries.map((entry) => ({
+              slot:
+                window &&
+                window.googletag
+                  .pubads()
+                  .getSlots()
+                  .find(
+                    (element) => element.getSlotElementId() === entry.target.id
+                  ),
+              target: entry.target
+            }))
+
+            displayEntries.forEach((element) => {
+              if (window && window.googletag && element.slot) {
+                window.googletag.display(element.slot.getSlotElementId())
+                window.googletag.pubads().refresh([element.slot])
+              }
+            })
+          })
+
+        actionEntries.forEach((element) => {
+          observer.unobserve(element.target)
+        })
+      }
+    })
+
+  const addToLazyLoad = useCallback((optDiv: string) => {
+    const element = document.getElementById(optDiv)
+    intersectionObserver && element && intersectionObserver.observe(element)
+  }, [])
 
   const registerSlot = useCallback(
     (slot: googletag.Slot) => {
@@ -37,6 +81,20 @@ export const AdManagerProvider: React.FC<Props> = ({
     [adManager]
   )
 
+  const removeFromLazyLoad = useCallback((optDiv) => {
+    const element = document.getElementById(optDiv)
+
+    intersectionObserver && element && intersectionObserver.unobserve(element)
+  }, [])
+
+  const addToLazyWithRetarget = useCallback(
+    (slot: googletag.Slot, optDiv: string) => {
+      intersectionObserver &&
+        adManager.retargetSlot(slot, optDiv, intersectionObserver)
+    },
+    []
+  )
+
   const shouldRefresh = useCallback((optDiv: string) => {
     return adsMap.includes(optDiv)
   }, adsMap)
@@ -48,8 +106,11 @@ export const AdManagerProvider: React.FC<Props> = ({
   return (
     <AdManagerContext.Provider
       value={{
+        addToLazyLoad,
+        addToLazyWithRetarget,
         refreshAd,
         registerSlot,
+        removeFromLazyLoad,
         shouldRefresh
       }}
     >

--- a/src/Utils/intersectionObserver.ts
+++ b/src/Utils/intersectionObserver.ts
@@ -1,0 +1,3 @@
+export function isIntersectionObserverAvailable() {
+  return window && 'IntersectionObserver' in window
+}

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -32,6 +32,11 @@ interface Googletag {
   sizeMapping(): googletag.SizeMappingBuilder
 }
 
+interface LazySlot {
+  slot: googletag.Slot
+  targetingReady: boolean
+}
+
 interface Window {
   googletag: Googletag
   // eslint-disable-next-line camelcase
@@ -43,6 +48,7 @@ interface Yieldbird {
   cmd: Function[]
   setGPTTargeting(slots: googletag.Slot[]): void
   refresh(slots?: googletag.Slot[]): void
+  retarget(slots?: googletag.Slot[]): void
 }
 
 declare module 'gpt-mock'

--- a/yarn.lock
+++ b/yarn.lock
@@ -6133,10 +6133,10 @@ ignore@^5.1.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immer@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
-  integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
+immer@1.10.0, immer@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
+  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
 import-cwd@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
<!-- Link to a JIRA task related to this changes -->
https://yieldbird.atlassian.net/browse/YIEL-3453

## Description

* Wsparcie dla lazy loadingu - zasada jest taka, że jeśli jednostka ma targeting, wrzucamy ją bezpośrednio do observera, jeśli nie, to najpierw ogarniemy na niej targeting z wykorzystaniem retarget, później gdy jest gotowy wrzucamy do observera.

* Observer odfiltrowuje jednostki które są we viewporcie, wykonuje display oraz refresh i usuwa (unobserve) z intersection observera.

* Zaktualizowałem dependency, które wywalało audyt.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.