### PR TITLE
Hotfix 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ return (
 | `onSlotResponseReceived` | function | false | Callback function for 'slotResponseReceived' event |
 | `onSlotVisibilityChanged` | function | false | Callback function for 'slotVisibilityChanged' event |
 
+You can find more about GPT events on the official [Google docs](https://developers.google.com/publisher-tag/reference#googletag.events.event). |
 
 `AdManagerSlot` is a simple ad component, with properties similar to GPT slot. It is responsible for rendering ad in specified place. You can use it with following properties:
 | name | type | required | description |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yieldbird_gpt_components",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Made with create-react-library",
   "author": "YieldbirdDev",
   "license": "MIT",

--- a/src/Components/AdManagerSlot.test.tsx
+++ b/src/Components/AdManagerSlot.test.tsx
@@ -105,10 +105,9 @@ describe('AdManagerSlot', () => {
       expect(window.googletag.cmd).toHaveLength(3)
       await wrapper.find('button').simulate('click')
 
-      expect(window.googletag.cmd).toHaveLength(5)
+      expect(window.googletag.cmd).toHaveLength(4)
       // destroy slot command
       window.googletag.cmd[3]()
-      window.googletag.cmd[4]()
 
       expect(window.googletag.destroySlots).toHaveBeenCalledTimes(1)
       await wrapper.find('button').simulate('click')
@@ -116,8 +115,7 @@ describe('AdManagerSlot', () => {
       // create slot command again
       expect(window.Yieldbird.cmd).toHaveLength(2)
       window.Yieldbird.cmd[1]()
-      window.googletag.cmd[5]()
-      window.googletag.cmd[6]()
+      window.googletag.cmd[4]()
 
       expect(window.googletag.enableServices).toHaveBeenCalledTimes(2)
       expect(window.googletag.defineSlot).toHaveBeenCalledTimes(2)

--- a/src/Context/AdManagerProvider.tsx
+++ b/src/Context/AdManagerProvider.tsx
@@ -48,17 +48,8 @@ export const AdManagerProvider: React.FC<Props> = ({
 }) => {
   const [adsMap, setAdsMap] = useState<string[]>([])
 
-  const adManager = new AdManager(
-    collapseEmptyDivs,
-    globalTargeting,
-    refreshDelay,
-    onImpressionViewable,
-    onSlotOnload,
-    onSlotRender,
-    onSlotRequested,
-    onSlotResponseReceived,
-    onSlotVisibilityChanged
-  )
+  const adManager = new AdManager(refreshDelay)
+
   const intersectionObserver =
     isIntersectionObserverAvailable() &&
     new IntersectionObserver((entries, observer) => {
@@ -137,6 +128,16 @@ export const AdManagerProvider: React.FC<Props> = ({
 
   useEffect(() => {
     initializeAdStack(uuid)
+    adManager.initiaizeGlobalGPTOptions(
+      collapseEmptyDivs,
+      globalTargeting,
+      onImpressionViewable,
+      onSlotOnload,
+      onSlotRender,
+      onSlotRequested,
+      onSlotResponseReceived,
+      onSlotVisibilityChanged
+    )
   }, [uuid])
 
   return (

--- a/src/Utils/AdManager.ts
+++ b/src/Utils/AdManager.ts
@@ -25,10 +25,20 @@ export class AdManager {
 
   private retargetTimeout: number
 
-  constructor(
+  constructor(timeout = 1000) {
+    this.adsToRefresh = {}
+    this.adsToRetarget = {}
+    this.refreshInterval = null
+    this.refreshTimeout = timeout
+    this.retargetInterval = null
+    this.retargetTimeout = timeout
+
+    ensureScripts()
+  }
+
+  public initiaizeGlobalGPTOptions(
     collapseEmptyDivs?: boolean,
     globalTargeting?: Record<string, string>,
-    timeout = 1000,
     onImpressionViewable?: (
       event: googletag.events.ImpressionViewableEvent
     ) => void,
@@ -41,15 +51,7 @@ export class AdManager {
     onSlotVisibilityChanged?: (
       event: googletag.events.SlotVisibilityChangedEvent
     ) => void
-  ) {
-    this.adsToRefresh = {}
-    this.adsToRetarget = {}
-    this.refreshInterval = null
-    this.refreshTimeout = timeout
-    this.retargetInterval = null
-    this.retargetTimeout = timeout
-
-    ensureScripts()
+  ): void {
     initiaizeGlobalGPTOptions(
       collapseEmptyDivs,
       globalTargeting,


### PR DESCRIPTION
Komponent przy przeładowaniu tworzył na nowo listenery. Zrobiłem zmianę by upewnić się, że listenery nie ustawią się ponownie.